### PR TITLE
Fix #32: Wrap `polypar` as a Python binding

### DIFF
--- a/include/polypar.h
+++ b/include/polypar.h
@@ -1,0 +1,55 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant API for the polypar routine: enumerates every combination of
+   exponents for a multivariate polynomial of a given order. Extracted out
+   of source_c/polypar.c so it can be called both from the polypar CLI and
+   from other bindings (e.g. Python) without going through global state or
+   argv parsing. */
+
+#ifndef _POLYPAR_H
+#define _POLYPAR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  unsigned int dim;
+  unsigned int order;
+  unsigned long count;   /* number of parameter combinations */
+  unsigned int *params;  /* [count][dim] flattened row-major: row i is
+			     params[i*dim .. i*dim+dim-1] */
+} PolyParResult;
+
+/* Enumerates every combination of dim non-negative integer exponents
+   (e_0, ..., e_{dim-1}) with e_0 + ... + e_{dim-1} <= order, in the same
+   order source_c/polypar.c's original make_parameter() recursion emitted
+   them. dim must be >= 1: like the original recursion this is based on,
+   passing dim == 0 is not a supported input (the recursion's depth
+   counter is dim - 1, computed as unsigned, so it underflows). */
+PolyParResult *polypar_generate(unsigned int dim, unsigned int order);
+void polypar_free(PolyParResult *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,11 +10,12 @@ find_package(pybind11 CONFIG REQUIRED)
 # Repo root: python/ is directly under it.
 set(TISEAN_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-# Only the sources ar-model needs. Other routines get added here as they
-# get their own reentrant API extracted.
+# Sources needed by ar-model and polypar. Other routines get added here as
+# they get their own reentrant API extracted.
 pybind11_add_module(_tisean
   src/bindings.cpp
   ${TISEAN_ROOT}/source_c/api/ar_model_api.c
+  ${TISEAN_ROOT}/source_c/api/polypar_api.c
   ${TISEAN_ROOT}/source_c/routines/check_alloc.c
   ${TISEAN_ROOT}/source_c/routines/variance.c
   ${TISEAN_ROOT}/source_c/routines/invert_matrix.c

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "ar-model.h"
+#include "polypar.h"
 
 namespace py = pybind11;
 
@@ -92,6 +93,44 @@ fit(py::array_t<double, py::array::c_style | py::array::forcecast> series,
   return std::make_unique<ARModelWrapper>(model);
 }
 
+// Owns a PolyParResult* and exposes its fields as numpy arrays. Not
+// copyable since PolyParResult doesn't support that; pybind11 holds it by
+// unique_ptr.
+class PolyParResultWrapper {
+public:
+  explicit PolyParResultWrapper(PolyParResult *result) : result_(result) {}
+  PolyParResultWrapper(const PolyParResultWrapper &) = delete;
+  PolyParResultWrapper &operator=(const PolyParResultWrapper &) = delete;
+  ~PolyParResultWrapper() { polypar_free(result_); }
+
+  unsigned int dim() const { return result_->dim; }
+  unsigned int order() const { return result_->order; }
+  unsigned long count() const { return result_->count; }
+
+  py::array_t<unsigned int> params() const {
+    unsigned int dim = result_->dim;
+    unsigned long count = result_->count;
+    py::array_t<unsigned int> out({(py::ssize_t)count, (py::ssize_t)dim});
+    auto buf = out.mutable_unchecked<2>();
+    for (unsigned long i = 0; i < count; i++)
+      for (unsigned int j = 0; j < dim; j++)
+	buf(i, j) = result_->params[i * dim + j];
+    return out;
+  }
+
+private:
+  PolyParResult *result_;
+};
+
+std::unique_ptr<PolyParResultWrapper> generate(unsigned int dim, unsigned int order)
+{
+  if (dim < 1)
+    throw std::invalid_argument("dim must be >= 1");
+
+  PolyParResult *result = polypar_generate(dim, order);
+  return std::make_unique<PolyParResultWrapper>(result);
+}
+
 } // namespace
 
 PYBIND11_MODULE(_tisean, m)
@@ -121,4 +160,19 @@ PYBIND11_MODULE(_tisean, m)
       "Fit a multivariate AR model to `series` (shape (dim, length)).\n\n"
       "series is expected to already be centered (zero mean per row), the\n"
       "same way the ar-model CLI centers its input before fitting.");
+
+  auto polypar = m.def_submodule(
+      "polypar", "Polynomial exponent enumeration (source_c/polypar.c)");
+
+  py::class_<PolyParResultWrapper>(polypar, "PolyParResult")
+      .def_property_readonly("dim", &PolyParResultWrapper::dim)
+      .def_property_readonly("order", &PolyParResultWrapper::order)
+      .def_property_readonly("count", &PolyParResultWrapper::count)
+      .def_property_readonly("params", &PolyParResultWrapper::params,
+			      "Exponent combinations, shape (count, dim)");
+
+  polypar.def(
+      "generate", &generate, py::arg("dim") = 2, py::arg("order") = 3,
+      "Enumerate every combination of `dim` non-negative integer exponents "
+      "that sum to at most `order`.");
 }

--- a/python/tisean/__init__.py
+++ b/python/tisean/__init__.py
@@ -1,4 +1,4 @@
 from . import _tisean
-from ._tisean import ar_model
+from ._tisean import ar_model, polypar
 
-__all__ = ["ar_model"]
+__all__ = ["ar_model", "polypar"]

--- a/source_c/CMakeLists.txt
+++ b/source_c/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(routines)
 set(TISEAN_C_PROGRAMS
   poincare extrema rescale recurr corr mutual false_nearest
   lyap_r lyap_k lyap_spec d2 av-d2 makenoise nrlazy low121
-  lzo-test lfo-run lfo-test rbf polynom polyback polynomp polypar
+  lzo-test lfo-run lfo-test rbf polynom polyback polynomp
   mem_spec pca ghkss lfo-ar xzero xcor boxcount fsle
   resample histogram nstat_z sav_gol delay lzo-gm arima-model
   lzo-run ar-run
@@ -20,3 +20,9 @@ endforeach()
 add_executable(ar-model ar-model.c api/ar_model_api.c)
 target_link_libraries(ar-model PRIVATE ddtsa)
 install(TARGETS ar-model RUNTIME DESTINATION bin)
+
+# polypar uses the reentrant API in api/polypar_api.c (also used by the
+# Python bindings under python/) instead of duplicating the math inline.
+add_executable(polypar polypar.c api/polypar_api.c)
+target_link_libraries(polypar PRIVATE ddtsa)
+install(TARGETS polypar RUNTIME DESTINATION bin)

--- a/source_c/api/polypar_api.c
+++ b/source_c/api/polypar_api.c
@@ -1,0 +1,106 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant core of polypar, factored out of source_c/polypar.c so it has
+   no dependency on argv parsing, file-scope globals, or writing straight
+   to a FILE*. The recursion here (a term's exponents are valid as soon as
+   their running sum stays <= order) is unchanged from the original
+   make_parameter(); only the "sink" for each finished combination changed,
+   from an fprintf into the CLI's output file to an append into a growable
+   in-memory buffer. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "../routines/tsa.h"
+#include "../../include/polypar.h"
+
+typedef struct {
+  unsigned int *rows;
+  unsigned long count;
+  unsigned long capacity;
+  unsigned int dim;
+} ParamBuffer;
+
+static void param_buffer_push(ParamBuffer *buf, const unsigned int *par)
+{
+  unsigned int j;
+
+  if (buf->count == buf->capacity) {
+    buf->capacity = (buf->capacity == 0) ? 64 : buf->capacity * 2;
+    check_alloc(buf->rows = (unsigned int *)realloc(
+	buf->rows, sizeof(unsigned int) * buf->capacity * buf->dim));
+  }
+  for (j = 0; j < buf->dim; j++)
+    buf->rows[buf->count * buf->dim + j] = par[j];
+  buf->count++;
+}
+
+static void make_parameter(ParamBuffer *buf, unsigned int order,
+			    unsigned int *par, unsigned int d,
+			    unsigned int sum)
+{
+  int i;
+
+  for (i = 0; i <= (int)order; i++) {
+    sum += i;
+    if (sum <= order) {
+      par[d] = i;
+      if (d == 0)
+	param_buffer_push(buf, par);
+      else
+	make_parameter(buf, order, par, d - 1, sum);
+    }
+    sum -= i;
+  }
+  par[d] = 0;
+}
+
+PolyParResult *polypar_generate(unsigned int dim, unsigned int order)
+{
+  unsigned int *par;
+  ParamBuffer buf;
+  PolyParResult *result;
+
+  check_alloc(par = (unsigned int *)malloc(sizeof(unsigned int) * dim));
+
+  buf.rows = NULL;
+  buf.count = 0;
+  buf.capacity = 0;
+  buf.dim = dim;
+
+  make_parameter(&buf, order, par, dim - 1, 0);
+
+  check_alloc(result = (PolyParResult *)malloc(sizeof(PolyParResult)));
+  result->dim = dim;
+  result->order = order;
+  result->count = buf.count;
+  result->params = buf.rows;
+
+  free(par);
+  return result;
+}
+
+void polypar_free(PolyParResult *result)
+{
+  if (result == NULL)
+    return;
+  free(result->params);
+  free(result);
+}

--- a/source_c/polypar.c
+++ b/source_c/polypar.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <limits.h>
 #include "routines/tsa.h"
+#include "../include/polypar.h"
 
 #define WID_STR "Creates a parameter file containing all terms\n\t\
 for a polynomial"
@@ -32,8 +33,6 @@ char *outfile=NULL;
 unsigned int dim=2,order=3;
 unsigned int verbosity=0xff;
 FILE *file=NULL;
-
-void make_parameter(unsigned int*,unsigned int, unsigned int);
 
 void show_options(char *progname)
 {
@@ -66,30 +65,10 @@ void scan_options(int n,char **in)
   }
 }
 
-void make_parameter(unsigned int *par,unsigned int d,unsigned int sum)
-{
-  int i,j;
-  
-  for (i=0;i<=order;i++) {
-    sum += i;
-    if (sum <= order) {
-      par[d]=i;
-      if (d == 0) {
-	for (j=0;j<dim;j++)
-	  fprintf(file,"%u ",par[j]);
-	fprintf(file,"\n");
-      }
-      else
-	make_parameter(par,d-1,sum);
-    }
-    sum -= i;
-  }
-  par[d]=0;
-}
-
 int main(int argc,char **argv)
 {
-  unsigned int i,*params;
+  unsigned int i,j;
+  PolyParResult *result;
 
   if (scan_help(argc,argv))
     show_options(argv[0]);
@@ -100,22 +79,25 @@ int main(int argc,char **argv)
     what_i_do(argv[0],WID_STR);
 #endif
 
-  
+
   if (outfile == NULL) {
     check_alloc(outfile=(char*)calloc((size_t)14,(size_t)1));
     sprintf(outfile,"parameter.pol");
   }
   test_outfile(outfile);
 
-  check_alloc(params=(unsigned int*)malloc(sizeof(unsigned int)*dim));
-  for (i=0;i<dim;i++)
-    params[i]=0;
+  result=polypar_generate(dim,order);
 
   file=fopen(outfile,"w");
   if (verbosity&VER_INPUT)
     fprintf(stderr,"Opened %s for writing\n",outfile);
-  make_parameter(params,dim-1,0);
+  for (i=0;i<result->count;i++) {
+    for (j=0;j<dim;j++)
+      fprintf(file,"%u ",result->params[i*dim+j]);
+    fprintf(file,"\n");
+  }
   fclose(file);
+  polypar_free(result);
 
   return 0;
 }

--- a/tests/test_polypar_bindings.py
+++ b/tests/test_polypar_bindings.py
@@ -1,0 +1,108 @@
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+tisean = pytest.importorskip("tisean")
+
+# The CLI prints integers with "%u ", so this doesn't strictly need the
+# tolerance the other bindings' tests need for "%e" output - but we keep
+# the same constant name/shape for consistency across the test suite.
+CLI_TEXT_TOL = dict(rtol=1e-6, atol=1e-6)
+
+POLYPAR_BIN = os.path.abspath("./bin/polypar")
+
+
+def run_cli(args, cwd):
+    # polypar always writes its parameter combinations to a file (never
+    # stdout) - so every invocation needs an explicit -o target to read
+    # the result back from.
+    outfile = os.path.join(str(cwd), "out.pol")
+    subprocess.run(
+        [POLYPAR_BIN] + list(args) + ["-o", outfile],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        check=True,
+    )
+    with open(outfile) as f:
+        return f.read()
+
+
+def parse_output(text):
+    rows = [
+        [int(x) for x in line.split()]
+        for line in text.splitlines()
+        if line.strip()
+    ]
+    return np.array(rows)
+
+
+CASES = [
+    # label, dim, order, extra_args
+    ("defaults", 2, 3, []),
+    ("dim1_order0", 1, 0, ["-m1", "-p0"]),
+    ("dim1_order5", 1, 5, ["-m1", "-p5"]),
+    ("dim3_order2", 3, 2, ["-m3", "-p2"]),
+    ("dim2_order0", 2, 0, ["-m2", "-p0"]),
+    ("verbosity_0", 2, 3, ["-V0"]),
+]
+
+
+@pytest.mark.parametrize(
+    "label,dim,order,extra_args", CASES, ids=[c[0] for c in CASES]
+)
+def test_generate_matches_cli(tmp_path, label, dim, order, extra_args):
+    out = run_cli(extra_args, cwd=tmp_path)
+    cli_rows = parse_output(out)
+
+    result = tisean.polypar.generate(dim=dim, order=order)
+
+    assert result.dim == dim
+    assert result.order == order
+    assert result.count == cli_rows.shape[0]
+    np.testing.assert_allclose(result.params, cli_rows, **CLI_TEXT_TOL)
+
+
+def test_generate_default_dim_and_order_match_cli_defaults():
+    default = tisean.polypar.generate()
+    explicit = tisean.polypar.generate(dim=2, order=3)
+
+    assert default.dim == explicit.dim == 2
+    assert default.order == explicit.order == 3
+    np.testing.assert_array_equal(default.params, explicit.params)
+
+
+def test_generate_dash_o_output_file_matches_python(tmp_path):
+    outfile = tmp_path / "out.pol"
+    subprocess.run(
+        [POLYPAR_BIN, "-m2", "-p3", "-o", str(outfile)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    cli_rows = parse_output(outfile.read_text())
+
+    result = tisean.polypar.generate(dim=2, order=3)
+
+    np.testing.assert_allclose(result.params, cli_rows, **CLI_TEXT_TOL)
+
+
+def test_generate_rejects_dim_zero():
+    # Unlike histogram's variance()/rescale_data() exit paths, the CLI has
+    # no defined/clean behaviour for -m0: source_c/polypar.c's original
+    # make_parameter() recursion is passed dim - 1 as an unsigned depth
+    # counter, which underflows for dim == 0 and recurses until the stack
+    # overflows. That's not something worth reproducing (or invoking) in a
+    # test - only the Python binding's own guard against this is checked
+    # here, so a bad `dim` can never crash the interpreter.
+    with pytest.raises(ValueError):
+        tisean.polypar.generate(dim=0, order=3)
+
+
+def test_params_shape_and_dtype():
+    result = tisean.polypar.generate(dim=2, order=3)
+
+    assert result.params.shape == (result.count, result.dim)
+    assert result.params.sum(axis=1).max() <= result.order


### PR DESCRIPTION
Generated by the TAEP Engineer worker.
Diverged because started off of develop.