### PR TITLE
Fix #34: ### Wrap `corr` as a Python binding

### DIFF
--- a/include/corr.h
+++ b/include/corr.h
@@ -1,0 +1,60 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant API for the corr routine: estimates the autocorrelation of a
+   data set. Extracted out of source_c/corr.c so it can be called both from
+   the corr CLI and from other bindings (e.g. Python) without going through
+   global state, argv parsing, or the process-exiting error path in
+   variance(). */
+
+#ifndef _CORR_H
+#define _CORR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  unsigned long length;  /* length of the input series actually used */
+  unsigned long tau;     /* maximum lag actually computed (clamped to
+			     length-1 if the requested tau was too large) */
+  double average;        /* mean of the raw (un-centered) series */
+  double stddev;         /* standard deviation of the raw series */
+  double *values;        /* [tau+1] correlation values for lags 0..tau */
+} CorrResult;
+
+/* Computes the autocorrelation of series[0..length-1] for lags 0..tau (tau
+   is clamped to length-1 if tau >= length). If normalize is non-zero, the
+   series is centered by its own mean before the autocovariance is computed
+   and each lag is divided by the variance, matching the CLI's default
+   behavior; if zero, the raw (uncentered) series is used and no division is
+   applied, matching the CLI's -n flag. series is not modified.
+
+   Returns NULL if length == 0 or the data is constant (variance == 0),
+   mirroring variance()'s hard-exit case but without exiting the process. */
+CorrResult *corr_compute(const double *series, unsigned long length,
+			  unsigned long tau, int normalize);
+void corr_free(CorrResult *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,11 +10,12 @@ find_package(pybind11 CONFIG REQUIRED)
 # Repo root: python/ is directly under it.
 set(TISEAN_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-# Only the sources ar-model needs. Other routines get added here as they
-# get their own reentrant API extracted.
+# Only the sources ar-model/corr need. Other routines get added here as
+# they get their own reentrant API extracted.
 pybind11_add_module(_tisean
   src/bindings.cpp
   ${TISEAN_ROOT}/source_c/api/ar_model_api.c
+  ${TISEAN_ROOT}/source_c/api/corr_api.c
   ${TISEAN_ROOT}/source_c/routines/check_alloc.c
   ${TISEAN_ROOT}/source_c/routines/variance.c
   ${TISEAN_ROOT}/source_c/routines/invert_matrix.c

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -1,7 +1,6 @@
-// pybind11 bindings for TISEAN's reentrant C APIs.
-// Starts with ar-model (source_c/api/ar_model_api.c); more routines will
-// get their own wrapper class/functions here (or their own .cpp file) as
-// they get the same "extract a reentrant API" treatment.
+// pybind11 bindings for TISEAN's reentrant C APIs (source_c/api/*.c). More
+// routines get their own wrapper class/functions here (or their own .cpp
+// file) as they get the same "extract a reentrant API" treatment.
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
@@ -11,6 +10,7 @@
 #include <vector>
 
 #include "ar-model.h"
+#include "corr.h"
 
 namespace py = pybind11;
 
@@ -92,6 +92,47 @@ fit(py::array_t<double, py::array::c_style | py::array::forcecast> series,
   return std::make_unique<ARModelWrapper>(model);
 }
 
+// Owns a CorrResult* and exposes its fields as numpy arrays. Not copyable
+// since CorrResult doesn't support that; pybind11 holds it by unique_ptr.
+class CorrResultWrapper {
+public:
+  explicit CorrResultWrapper(CorrResult *result) : result_(result) {}
+  CorrResultWrapper(const CorrResultWrapper &) = delete;
+  CorrResultWrapper &operator=(const CorrResultWrapper &) = delete;
+  ~CorrResultWrapper() { corr_free(result_); }
+
+  unsigned long length() const { return result_->length; }
+  unsigned long tau() const { return result_->tau; }
+  double average() const { return result_->average; }
+  double stddev() const { return result_->stddev; }
+
+  py::array_t<double> values() const {
+    py::array_t<double> out((py::ssize_t)(result_->tau + 1));
+    auto buf = out.mutable_unchecked<1>();
+    for (unsigned long i = 0; i <= result_->tau; i++)
+      buf(i) = result_->values[i];
+    return out;
+  }
+
+private:
+  CorrResult *result_;
+};
+
+std::unique_ptr<CorrResultWrapper>
+corr_compute_binding(py::array_t<double, py::array::c_style | py::array::forcecast> series,
+		      unsigned long tau, bool normalize)
+{
+  if (series.ndim() != 1)
+    throw std::invalid_argument("series must be a 1D array");
+
+  auto length = (unsigned long)series.shape(0);
+  CorrResult *result = corr_compute(series.data(), length, tau, normalize ? 1 : 0);
+  if (result == nullptr)
+    throw std::invalid_argument("series must be non-empty and non-constant");
+
+  return std::make_unique<CorrResultWrapper>(result);
+}
+
 } // namespace
 
 PYBIND11_MODULE(_tisean, m)
@@ -121,4 +162,27 @@ PYBIND11_MODULE(_tisean, m)
       "Fit a multivariate AR model to `series` (shape (dim, length)).\n\n"
       "series is expected to already be centered (zero mean per row), the\n"
       "same way the ar-model CLI centers its input before fitting.");
+
+  auto corr = m.def_submodule(
+      "corr", "Autocorrelation estimation (source_c/corr.c)");
+
+  py::class_<CorrResultWrapper>(corr, "CorrResult")
+      .def_property_readonly("length", &CorrResultWrapper::length)
+      .def_property_readonly("tau", &CorrResultWrapper::tau,
+			      "Maximum lag actually computed")
+      .def_property_readonly("average", &CorrResultWrapper::average,
+			      "Mean of the raw (un-centered) series")
+      .def_property_readonly("stddev", &CorrResultWrapper::stddev,
+			      "Standard deviation of the raw series")
+      .def_property_readonly("values", &CorrResultWrapper::values,
+			      "Correlation values for lags 0..tau, shape (tau+1,)");
+
+  corr.def(
+      "compute", &corr_compute_binding, py::arg("series"), py::arg("tau") = 100,
+      py::arg("normalize") = true,
+      "Estimate the autocorrelation of `series` for lags 0..tau (tau is\n"
+      "clamped to len(series)-1 if too large). If normalize is True\n"
+      "(default), the series is centered by its own mean and each lag is\n"
+      "divided by the variance; if False, the raw series is used\n"
+      "unscaled, matching the CLI's -n flag.");
 }

--- a/python/tisean/__init__.py
+++ b/python/tisean/__init__.py
@@ -1,4 +1,4 @@
 from . import _tisean
-from ._tisean import ar_model
+from ._tisean import ar_model, corr
 
-__all__ = ["ar_model"]
+__all__ = ["ar_model", "corr"]

--- a/source_c/CMakeLists.txt
+++ b/source_c/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(routines)
 
 set(TISEAN_C_PROGRAMS
-  poincare extrema rescale recurr corr mutual false_nearest
+  poincare extrema rescale recurr mutual false_nearest
   lyap_r lyap_k lyap_spec d2 av-d2 makenoise nrlazy low121
   lzo-test lfo-run lfo-test rbf polynom polyback polynomp polypar
   mem_spec pca ghkss lfo-ar xzero xcor boxcount fsle
@@ -20,3 +20,9 @@ endforeach()
 add_executable(ar-model ar-model.c api/ar_model_api.c)
 target_link_libraries(ar-model PRIVATE ddtsa)
 install(TARGETS ar-model RUNTIME DESTINATION bin)
+
+# corr uses the reentrant API in api/corr_api.c (also used by the Python
+# bindings under python/) instead of duplicating the math inline.
+add_executable(corr corr.c api/corr_api.c)
+target_link_libraries(corr PRIVATE ddtsa)
+install(TARGETS corr RUNTIME DESTINATION bin)

--- a/source_c/api/corr_api.c
+++ b/source_c/api/corr_api.c
@@ -1,0 +1,94 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant core of corr, factored out of source_c/corr.c so it has no
+   dependency on argv parsing, file-scope globals, or the process-exiting
+   error path in the generic variance() library routine it used to call.
+   The math here (mean/variance via a plain sequential sum, optional
+   centering, sum-of-products autocovariance per lag) is unchanged from
+   main()/corr(). */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../routines/tsa.h"
+#include "../../include/corr.h"
+
+CorrResult *corr_compute(const double *series, unsigned long length,
+			  unsigned long tau, int normalize)
+{
+  unsigned long i;
+  long j;
+  double av, var, h, norm_div, c;
+  double *array;
+  CorrResult *result;
+
+  if (length == 0)
+    return NULL;
+
+  av = var = 0.0;
+  for (i = 0; i < length; i++) {
+    h = series[i];
+    av += h;
+    var += h * h;
+  }
+  av /= (double)length;
+  var = sqrt(fabs(var / (double)length - av * av));
+  if (var == 0.0)
+    return NULL;
+
+  if (tau >= length)
+    tau = length - 1;
+
+  check_alloc(array = (double *)malloc(sizeof(double) * length));
+  for (i = 0; i < length; i++)
+    array[i] = series[i];
+  if (normalize) {
+    for (i = 0; i < length; i++)
+      array[i] -= av;
+  }
+
+  check_alloc(result = (CorrResult *)malloc(sizeof(CorrResult)));
+  result->length = length;
+  result->tau = tau;
+  result->average = av;
+  result->stddev = var;
+  check_alloc(result->values = (double *)malloc(sizeof(double) * (tau + 1)));
+
+  norm_div = normalize ? (var * var) : 1.0;
+  for (i = 0; i <= tau; i++) {
+    c = 0.0;
+    for (j = 0; j < (long)(length - i); j++)
+      c += array[j] * array[j + i];
+    c /= (double)(length - i);
+    result->values[i] = c / norm_div;
+  }
+
+  free(array);
+  return result;
+}
+
+void corr_free(CorrResult *result)
+{
+  if (result == NULL)
+    return;
+  free(result->values);
+  free(result);
+}

--- a/source_c/corr.c
+++ b/source_c/corr.c
@@ -24,6 +24,7 @@
 #include <limits.h>
 #include <string.h>
 #include "routines/tsa.h"
+#include "../include/corr.h"
 
 #define WID_STR "Estimates the autocorrelations of a data set"
 
@@ -32,7 +33,6 @@ unsigned int column=1;
 unsigned int verbosity=0xff;
 unsigned long tau=100,length=ULONG_MAX,exclude=0;
 double *array;
-double av,var;
 char *infile=NULL;
 
 void show_options(char *progname) 
@@ -83,23 +83,13 @@ void scan_options(int argc,char **argv)
   }
 }
 
-double corr(long i)
-{
-  long j;
-  double c=0.0;
-  
-  for (j=0;j<(length-i);j++)
-    c += array[j]*array[j+i];
-
-  return c/(length-i);
-}
-
 int main(int argc,char** argv)
 {
   char stdi=0;
   long i;
   FILE *fout=NULL;
-  
+  CorrResult *result;
+
   if (scan_help(argc,argv))
     show_options(argv[0]);
   
@@ -129,41 +119,33 @@ int main(int argc,char** argv)
 
   array=(double*)get_series(infile,&length,exclude,column,verbosity);
 
-  if (tau >= length)
-    tau=length-1;
-
-  variance(array,length,&av,&var);
-
-  if (normalize) {
-    for (i=0;i<length;i++)
-      array[i] -= av;
+  result=corr_compute(array,length,tau,normalize);
+  if (result == NULL) {
+    fprintf(stderr,"Variance of the data is zero. Exiting!\n\n");
+    exit(VARIANCE_VAR_EQ_ZERO);
   }
 
   if (!stout) {
     fout=fopen(outfile,"w");
     if (verbosity&VER_INPUT)
       fprintf(stderr,"Opened %s for writing\n",outfile);
-    fprintf(fout,"# average=%e\n",av);
-    fprintf(fout,"# standard deviation=%e\n",var);
+    fprintf(fout,"# average=%e\n",result->average);
+    fprintf(fout,"# standard deviation=%e\n",result->stddev);
   }
   else {
     if (verbosity&VER_INPUT)
       fprintf(stderr,"Writing to stdout\n");
-    fprintf(stdout,"# average=%e\n",av);
-    fprintf(stdout,"# standard deviation=%e\n",var);
+    fprintf(stdout,"# average=%e\n",result->average);
+    fprintf(stdout,"# standard deviation=%e\n",result->stddev);
   }
-  if (normalize)
-    var *= var;
-  else
-    var=1.0;
 
-  for (i=0;i<=tau;i++)
+  for (i=0;i<=result->tau;i++)
     if (!stout) {
-      fprintf(fout,"%ld %e\n",i,corr(i)/var);
+      fprintf(fout,"%ld %e\n",i,result->values[i]);
       fflush(fout);
     }
     else {
-      fprintf(stdout,"%ld %e\n",i,corr(i)/var);
+      fprintf(stdout,"%ld %e\n",i,result->values[i]);
       fflush(stdout);
     }
   if (!stout)
@@ -174,6 +156,7 @@ int main(int argc,char** argv)
   if (infile != NULL)
     free(infile);
   free(array);
+  corr_free(result);
 
   return 0;
 }

--- a/tests/test_corr_bindings.py
+++ b/tests/test_corr_bindings.py
@@ -1,0 +1,143 @@
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+tisean = pytest.importorskip("tisean")
+
+# The CLI prints with "%e" (6 digits after the point, ~7 significant
+# digits), so comparisons against numbers parsed from its stdout can't be
+# tighter than that text roundtrip allows.
+CLI_TEXT_TOL = dict(rtol=1e-6, atol=1e-6)
+
+VARIANCE_VAR_EQ_ZERO = 23
+
+AR_RUN = "tests/refs/ar-run_l1000.txt"
+HENON = "tests/refs/henon_l1000.txt"
+CORR_BIN = os.path.abspath("./bin/corr")
+
+
+def run_cli(args, **kwargs):
+    result = subprocess.run(
+        [CORR_BIN] + args,
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+    return result.stdout
+
+
+def parse_output(text):
+    """Returns (average, stddev, rows) where rows is a (tau+1, 2) array of
+    [lag, value], matching what the CLI actually prints: a '# average=' and
+    a '# standard deviation=' comment line, then one 'lag value' row per
+    lag."""
+    lines = [line for line in text.splitlines() if line.strip()]
+    average = float(lines[0].split("=")[1])
+    stddev = float(lines[1].split("=")[1])
+    rows = [[float(x) for x in line.split()] for line in lines[2:]]
+    return average, stddev, np.array(rows)
+
+
+def load_column(path, column, length=None, exclude=0):
+    raw = np.loadtxt(path)
+    if raw.ndim == 1:
+        raw = raw.reshape(-1, 1)
+    if exclude:
+        raw = raw[exclude:]
+    if length is not None:
+        raw = raw[:length]
+    return raw[:, column - 1].copy()
+
+
+CASES = [
+    # label, args, datafile, column, length, exclude, tau, normalize
+    ("defaults", [], AR_RUN, 1, None, 0, 100, True),
+    ("tau_20", ["-D20"], AR_RUN, 1, None, 0, 20, True),
+    ("tau_5", ["-D5"], AR_RUN, 1, None, 0, 5, True),
+    ("no_normalize", ["-n"], AR_RUN, 1, None, 0, 100, False),
+    ("column_2", ["-c2"], HENON, 2, None, 0, 100, True),
+    ("length", ["-l300"], AR_RUN, 1, 300, 0, 100, True),
+    ("exclude", ["-x50"], AR_RUN, 1, None, 50, 100, True),
+    ("length_and_exclude", ["-l300", "-x50", "-D20"], AR_RUN, 1, 300, 50, 20, True),
+    ("verbosity_0", ["-V0"], AR_RUN, 1, None, 0, 100, True),
+]
+
+
+@pytest.mark.parametrize(
+    "label,args,datafile,column,length,exclude,tau,normalize",
+    CASES,
+    ids=[c[0] for c in CASES],
+)
+def test_compute_matches_cli(label, args, datafile, column, length, exclude, tau, normalize):
+    out = run_cli(args + [datafile])
+    cli_average, cli_stddev, cli_rows = parse_output(out)
+
+    series = load_column(datafile, column, length=length, exclude=exclude)
+    result = tisean.corr.compute(series, tau=tau, normalize=normalize)
+
+    assert result.tau == tau
+    assert result.length == len(series)
+    np.testing.assert_allclose(result.average, cli_average, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(result.stddev, cli_stddev, **CLI_TEXT_TOL)
+
+    np.testing.assert_array_equal(cli_rows[:, 0], np.arange(tau + 1))
+    np.testing.assert_allclose(result.values, cli_rows[:, 1], **CLI_TEXT_TOL)
+
+
+def test_compute_matches_cli_dash_o_output_file(tmp_path):
+    outfile = tmp_path / "out.cor"
+    run_cli(["-D10", "-o" + str(outfile), AR_RUN])
+
+    cli_average, cli_stddev, cli_rows = parse_output(outfile.read_text())
+
+    series = load_column(AR_RUN, 1)
+    result = tisean.corr.compute(series, tau=10)
+
+    np.testing.assert_allclose(result.average, cli_average, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(result.stddev, cli_stddev, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(result.values, cli_rows[:, 1], **CLI_TEXT_TOL)
+
+
+def test_compute_clamps_tau_to_length_minus_one_like_cli():
+    length = 50
+
+    out = run_cli(["-l50", "-D1000", AR_RUN])
+    cli_average, cli_stddev, cli_rows = parse_output(out)
+    assert cli_rows.shape[0] == length
+
+    series = load_column(AR_RUN, 1, length=length)
+    result = tisean.corr.compute(series, tau=1000)
+
+    assert result.tau == length - 1
+    np.testing.assert_allclose(result.average, cli_average, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(result.stddev, cli_stddev, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(result.values, cli_rows[:, 1], **CLI_TEXT_TOL)
+
+
+def test_compute_default_tau_and_normalize():
+    series = load_column(AR_RUN, 1)
+
+    default = tisean.corr.compute(series)
+    explicit = tisean.corr.compute(series, tau=100, normalize=True)
+
+    assert default.tau == explicit.tau == 100
+    np.testing.assert_array_equal(default.values, explicit.values)
+
+
+def test_compute_rejects_constant_data_like_cli(tmp_path):
+    datafile = tmp_path / "constant.txt"
+    datafile.write_text("\n".join(["1.5"] * 20) + "\n")
+
+    result = subprocess.run(
+        [CORR_BIN, str(datafile)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == VARIANCE_VAR_EQ_ZERO
+
+    series = np.full(20, 1.5)
+    with pytest.raises(ValueError):
+        tisean.corr.compute(series)


### PR DESCRIPTION
Generated by the TAEP Engineer worker.