### PR TITLE
Fix #45: Wrap `recurr` as a Python binding

### DIFF
--- a/include/recurr.h
+++ b/include/recurr.h
@@ -1,0 +1,75 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant API for the recurr routine: finds recurrence-plot neighbor
+   pairs in (possibly multivariate, delay-embedded) data. Extracted out of
+   source_c/recurr.c so it can be called both from the recurr CLI and from
+   other bindings (e.g. Python) without going through global state, argv
+   parsing, or the process-exiting error path in rescale_data(). */
+
+#ifndef _RECURR_H
+#define _RECURR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  unsigned long count;  /* number of neighbor pairs found */
+  long *point;           /* [count] 1-based index of the scanned point */
+  long *neighbor;         /* [count] 1-based index of its recurrence neighbor */
+} RecurrResult;
+
+/* Finds recurrence-plot neighbor pairs in series (shape [dim][length]),
+   mirroring source_c/recurr.c's main()/lfind_neighbors(). Each dimension
+   of series is independently rescaled to [0,1) the same way rescale_data()
+   does it, but without exiting the process on a constant dimension: if any
+   dimension is constant (max == min), NULL is returned and, if bad_value
+   is non-NULL, *bad_value is set to that dimension's constant value
+   (matching what rescale_data()'s "data ranges from %e to %e" message
+   would have printed - both %e are that same value). series is not
+   modified.
+
+   If eps_is_raw is non-zero, eps is interpreted in the original (raw) data
+   units and divided by the largest of the per-dimension raw intervals
+   before use, matching the CLI's -r flag; if zero, eps is used as-is in
+   the already-rescaled [0,1) space, matching the CLI's default (a plain
+   1.e-3, i.e. "(data interval)/1000").
+
+   For every scanned point n in (embed-1)*delay..length-1, every other
+   point `element` (< n) within Chebyshev distance eps across all `embed`
+   delayed copies of all `dim` rescaled components is a candidate neighbor;
+   each candidate is kept with probability `fraction`, drawn from the same
+   fixed-seed rnd69069() generator the CLI uses (rnd_init() only actually
+   reseeds once per process - see routines/rand.c - so results depend on
+   any earlier RNG use within the same process, exactly like the CLI).
+
+   Returns NULL (without touching *bad_value) if dim == 0 or length == 0. */
+RecurrResult *recurr_find(double *const *series, unsigned long length,
+			   unsigned int dim, unsigned int embed,
+			   unsigned int delay, double eps, char eps_is_raw,
+			   double fraction, double *bad_value);
+void recurr_free(RecurrResult *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(pybind11 CONFIG REQUIRED)
 set(TISEAN_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 # Only the sources ar-model/low121/histogram/polypar/corr/xcor/av-d2/mutual/
-# extrema need. Other routines get added here as they get their own
+# extrema/recurr need. Other routines get added here as they get their own
 # reentrant API extracted.
 pybind11_add_module(_tisean
   src/bindings.cpp
@@ -24,11 +24,13 @@ pybind11_add_module(_tisean
   ${TISEAN_ROOT}/source_c/api/av-d2_api.c
   ${TISEAN_ROOT}/source_c/api/mutual_api.c
   ${TISEAN_ROOT}/source_c/api/extrema_api.c
+  ${TISEAN_ROOT}/source_c/api/recurr_api.c
   ${TISEAN_ROOT}/source_c/routines/check_alloc.c
   ${TISEAN_ROOT}/source_c/routines/variance.c
   ${TISEAN_ROOT}/source_c/routines/invert_matrix.c
   ${TISEAN_ROOT}/source_c/routines/solvele.c
   ${TISEAN_ROOT}/source_c/routines/rand.c
+  ${TISEAN_ROOT}/source_c/routines/make_multi_box.c
 )
 
 target_include_directories(_tisean PRIVATE ${TISEAN_ROOT}/include)

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -18,6 +18,7 @@
 #include "av-d2.h"
 #include "mutual.h"
 #include "extrema.h"
+#include "recurr.h"
 
 namespace py = pybind11;
 
@@ -432,6 +433,64 @@ extrema_find_binding(py::array_t<double, py::array::c_style | py::array::forceca
   return std::make_unique<ExtremaResultWrapper>(result);
 }
 
+// Owns a RecurrResult* and exposes its fields as numpy arrays. Not copyable
+// since RecurrResult doesn't support that; pybind11 holds it by
+// unique_ptr.
+class RecurrResultWrapper {
+public:
+  explicit RecurrResultWrapper(RecurrResult *result) : result_(result) {}
+  RecurrResultWrapper(const RecurrResultWrapper &) = delete;
+  RecurrResultWrapper &operator=(const RecurrResultWrapper &) = delete;
+  ~RecurrResultWrapper() { recurr_free(result_); }
+
+  unsigned long count() const { return result_->count; }
+
+  py::array_t<long> point() const {
+    py::array_t<long> out((py::ssize_t)result_->count);
+    auto buf = out.mutable_unchecked<1>();
+    for (unsigned long i = 0; i < result_->count; i++)
+      buf(i) = result_->point[i];
+    return out;
+  }
+
+  py::array_t<long> neighbor() const {
+    py::array_t<long> out((py::ssize_t)result_->count);
+    auto buf = out.mutable_unchecked<1>();
+    for (unsigned long i = 0; i < result_->count; i++)
+      buf(i) = result_->neighbor[i];
+    return out;
+  }
+
+private:
+  RecurrResult *result_;
+};
+
+std::unique_ptr<RecurrResultWrapper>
+recurr_find_binding(py::array_t<double, py::array::c_style | py::array::forcecast> series,
+		     unsigned int embed, unsigned int delay, double eps,
+		     bool eps_is_raw, double fraction)
+{
+  if (series.ndim() != 2)
+    throw std::invalid_argument("series must be a 2D array of shape (dim, length)");
+
+  auto dim = (unsigned int)series.shape(0);
+  auto length = (unsigned long)series.shape(1);
+
+  std::vector<double *> rows(dim);
+  for (unsigned int i = 0; i < dim; i++)
+    rows[i] = series.mutable_data(i, 0);
+
+  double bad_value = 0.0;
+  RecurrResult *result = recurr_find(rows.data(), length, dim, embed, delay, eps,
+				      eps_is_raw ? 1 : 0, fraction, &bad_value);
+  if (result == nullptr)
+    throw std::invalid_argument(
+	"series must be non-empty and have no constant dimension (a dimension "
+	"ranges from " + std::to_string(bad_value) + " to " + std::to_string(bad_value) + ")");
+
+  return std::make_unique<RecurrResultWrapper>(result);
+}
+
 } // namespace
 
 PYBIND11_MODULE(_tisean, m)
@@ -620,4 +679,30 @@ PYBIND11_MODULE(_tisean, m)
       "matching the extrema CLI's -w/-z/-t options. For every extremum "
       "found, every component of series is interpolated at the extremum's "
       "fractional time via the same parabola fit.");
+
+  auto recurr = m.def_submodule(
+      "recurr", "Recurrence plot neighbor search (source_c/recurr.c)");
+
+  py::class_<RecurrResultWrapper>(recurr, "RecurrResult")
+      .def_property_readonly("count", &RecurrResultWrapper::count)
+      .def_property_readonly("point", &RecurrResultWrapper::point,
+			      "1-based index of the scanned point, shape (count,)")
+      .def_property_readonly("neighbor", &RecurrResultWrapper::neighbor,
+			      "1-based index of the recurrence neighbor, "
+			      "shape (count,)");
+
+  recurr.def(
+      "find", &recurr_find_binding, py::arg("series"), py::arg("embed") = 2,
+      py::arg("delay") = 1, py::arg("eps") = 1.e-3,
+      py::arg("eps_is_raw") = false, py::arg("fraction") = 1.0,
+      "Find recurrence-plot neighbor pairs in `series` (shape (dim, "
+      "length)). Each dimension is independently rescaled to [0,1) the "
+      "same way the CLI does it. If eps_is_raw is True, `eps` is "
+      "interpreted in the original (raw) data units and divided by the "
+      "largest per-dimension raw interval before use, matching the CLI's "
+      "-r flag; if False (default), `eps` is used as-is in the "
+      "already-rescaled [0,1) space, matching the CLI's default. `embed` "
+      "and `delay` match the CLI's -m (embedding dimension part) and -d; "
+      "`fraction` matches the CLI's -% (as a 0..1 fraction rather than a "
+      "percentage).");
 }

--- a/python/tisean/__init__.py
+++ b/python/tisean/__init__.py
@@ -1,4 +1,4 @@
 from . import _tisean
-from ._tisean import ar_model, low121, histogram, polypar, corr, xcor, av_d2, mutual, extrema
+from ._tisean import ar_model, low121, histogram, polypar, corr, xcor, av_d2, mutual, extrema, recurr
 
-__all__ = ["ar_model", "low121", "histogram", "polypar", "corr", "xcor", "av_d2", "mutual", "extrema"]
+__all__ = ["ar_model", "low121", "histogram", "polypar", "corr", "xcor", "av_d2", "mutual", "extrema", "recurr"]

--- a/source_c/CMakeLists.txt
+++ b/source_c/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(routines)
 
 set(TISEAN_C_PROGRAMS
-  poincare rescale recurr false_nearest
+  poincare rescale false_nearest
   lyap_r lyap_k lyap_spec d2 makenoise nrlazy
   lzo-test lfo-run lfo-test rbf polynom polyback polynomp
   mem_spec pca ghkss lfo-ar xzero boxcount fsle
@@ -15,9 +15,9 @@ foreach(prog ${TISEAN_C_PROGRAMS})
   install(TARGETS ${prog} RUNTIME DESTINATION bin)
 endforeach()
 
-# ar-model, low121, histogram, polypar, corr, xcor, av-d2, mutual and
-# extrema use the reentrant APIs in api/ (also used by the Python bindings
-# under python/) instead of duplicating the math inline.
+# ar-model, low121, histogram, polypar, corr, xcor, av-d2, mutual, extrema
+# and recurr use the reentrant APIs in api/ (also used by the Python
+# bindings under python/) instead of duplicating the math inline.
 add_executable(ar-model ar-model.c api/ar_model_api.c)
 target_link_libraries(ar-model PRIVATE ddtsa)
 install(TARGETS ar-model RUNTIME DESTINATION bin)
@@ -53,3 +53,7 @@ install(TARGETS mutual RUNTIME DESTINATION bin)
 add_executable(extrema extrema.c api/extrema_api.c)
 target_link_libraries(extrema PRIVATE ddtsa)
 install(TARGETS extrema RUNTIME DESTINATION bin)
+
+add_executable(recurr recurr.c api/recurr_api.c)
+target_link_libraries(recurr PRIVATE ddtsa)
+install(TARGETS recurr RUNTIME DESTINATION bin)

--- a/source_c/api/recurr_api.c
+++ b/source_c/api/recurr_api.c
@@ -1,0 +1,166 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant core of recurr, factored out of source_c/recurr.c so it has no
+   dependency on argv parsing, file-scope globals, or the process-exiting
+   error path in the generic rescale_data() library routine it used to
+   call. The math here (per-dimension rescale to [0,1), the box-assisted
+   neighbor search and its fraction-based random thinning) is unchanged
+   from main()/lfind_neighbors(); the only difference is that found
+   neighbor pairs are appended to a growable array instead of being
+   printed immediately. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <limits.h>
+#include "../routines/tsa.h"
+#include "../../include/recurr.h"
+
+#define BOX 1024
+#define RECURR_CHUNK 1024
+
+RecurrResult *recurr_find(double *const *series, unsigned long length,
+			   unsigned int dim, unsigned int embed,
+			   unsigned int delay, double eps, char eps_is_raw,
+			   double fraction, double *bad_value)
+{
+  unsigned int d;
+  unsigned long ui;
+  int i,i1,i2,j,j1,ke,ked,kd;
+  int ibox=BOX-1;
+  long n,element;
+  double dx,epsinv,min,interval,maxinterval;
+  double **rescaled;
+  long **box,*list;
+  char toolarge;
+  unsigned long capacity,count;
+  long *point,*neighbor;
+  RecurrResult *result;
+
+  if (dim == 0 || length == 0)
+    return NULL;
+
+  check_alloc(rescaled=(double**)malloc(sizeof(double*)*dim));
+  maxinterval=0.0;
+  for (d=0;d<dim;d++) {
+    check_alloc(rescaled[d]=(double*)malloc(sizeof(double)*length));
+    min=interval=series[d][0];
+    for (ui=1;ui<length;ui++) {
+      if (series[d][ui] < min)
+	min=series[d][ui];
+      if (series[d][ui] > interval)
+	interval=series[d][ui];
+    }
+    interval -= min;
+    if (interval == 0.0) {
+      if (bad_value != NULL)
+	*bad_value=min;
+      for (ui=0;ui<=d;ui++)
+	free(rescaled[ui]);
+      free(rescaled);
+      return NULL;
+    }
+    for (ui=0;ui<length;ui++)
+      rescaled[d][ui]=(series[d][ui]-min)/interval;
+    if (interval > maxinterval)
+      maxinterval=interval;
+  }
+
+  if (eps_is_raw)
+    eps /= maxinterval;
+
+  check_alloc(list=(long*)malloc(sizeof(long)*length));
+  check_alloc(box=(long**)malloc(sizeof(long*)*BOX));
+  for (ui=0;ui<BOX;ui++)
+    check_alloc(box[ui]=(long*)malloc(sizeof(long)*BOX));
+
+  make_multi_box(rescaled,box,list,length,BOX,dim,embed,delay,eps);
+
+  epsinv=1./eps;
+  rnd_init(0x9834725L);
+
+  capacity=RECURR_CHUNK;
+  count=0;
+  check_alloc(point=(long*)malloc(sizeof(long)*capacity));
+  check_alloc(neighbor=(long*)malloc(sizeof(long)*capacity));
+
+  for (n=(long)((embed-1)*delay);(unsigned long)n<length;n++) {
+    i=(int)(rescaled[0][n]*epsinv)&ibox;
+    j=(int)(rescaled[dim-1][n]*epsinv)&ibox;
+    for (i1=i-1;i1<=i+1;i1++) {
+      i2=i1&ibox;
+      for (j1=j-1;j1<=j+1;j1++) {
+	element=box[i2][j1&ibox];
+	while (element > n) {
+	  toolarge=0;
+	  for (ke=0;ke<(int)embed;ke++) {
+	    ked=ke*delay;
+	    for (kd=0;kd<(int)dim;kd++) {
+	      dx=fabs(rescaled[kd][n-ked]-rescaled[kd][element-ked]);
+	      if (dx >= eps) {
+		toolarge=1;
+		break;
+	      }
+	    }
+	    if (toolarge)
+	      break;
+	  }
+	  if (!toolarge) {
+	    if (((double)rnd69069()/ULONG_MAX) <= fraction) {
+	      if (count == capacity) {
+		capacity += RECURR_CHUNK;
+		check_alloc(point=(long*)realloc(point,sizeof(long)*capacity));
+		check_alloc(neighbor=(long*)realloc(neighbor,sizeof(long)*capacity));
+	      }
+	      point[count]=n+1;
+	      neighbor[count]=element+1;
+	      count++;
+	    }
+	  }
+	  element=list[element];
+	}
+      }
+    }
+  }
+
+  for (ui=0;ui<BOX;ui++)
+    free(box[ui]);
+  free(box);
+  free(list);
+  for (d=0;d<dim;d++)
+    free(rescaled[d]);
+  free(rescaled);
+
+  check_alloc(result=(RecurrResult*)malloc(sizeof(RecurrResult)));
+  result->count=count;
+  result->point=point;
+  result->neighbor=neighbor;
+  return result;
+}
+
+void recurr_free(RecurrResult *result)
+{
+  if (result == NULL)
+    return;
+  free(result->point);
+  free(result->neighbor);
+  free(result);
+}

--- a/source_c/recurr.c
+++ b/source_c/recurr.c
@@ -26,10 +26,9 @@
 #include <math.h>
 #include <limits.h>
 #include "routines/tsa.h"
+#include "../include/recurr.h"
 
 #define WID_STR "This programs makes a recurrence plot for the data."
-
-#define BOX 1024
 
 unsigned long length=ULONG_MAX,exclude=0;
 unsigned int embed=2,dim=1,delay=1;
@@ -42,7 +41,6 @@ char *infile=NULL;
 char epsset=0;
 
 double **series;
-long **box,*list;
 
 void show_options(char *progname)
 {
@@ -104,70 +102,13 @@ void scan_options(int n,char **in)
   }
 }
 
-void lfind_neighbors(void)
-{
-  int i,i1,i2,j,j1,ke,ked,kd;
-  int ibox=BOX-1;
-  long n,element;
-  double dx,epsinv;
-  char toolarge;
-  FILE *fout=NULL;
-
-  epsinv=1./eps;
-  rnd_init(0x9834725L);
-
-  if (!stdo) {
-    fout=fopen(outfile,"w");
-    if (verbosity&VER_INPUT)
-      fprintf(stderr,"Opened %s for writing\n",outfile);
-  }
-  else {
-    if (verbosity&VER_INPUT)
-      fprintf(stderr,"Writing to stdout\n");
-  }
-
-  for (n=(embed-1)*delay;n<length;n++) {
-    i=(int)(series[0][n]*epsinv)&ibox;
-    j=(int)(series[dim-1][n]*epsinv)&ibox;
-    for (i1=i-1;i1<=i+1;i1++) {
-      i2=i1&ibox;
-      for (j1=j-1;j1<=j+1;j1++) {
-	element=box[i2][j1&ibox];
-	while (element > n) {
-	  toolarge=0;
-	  for (ke=0;ke<embed;ke++) {
-	    ked=ke*delay;
-	    for (kd=0;kd<dim;kd++) {
-	      dx=fabs(series[kd][n-ked]-series[kd][element-ked]);
-	      if (dx >= eps) {
-		toolarge=1;
-		break;
-	      }
-	    }
-	    if (toolarge)
-	      break;
-	  }
-	  if (!toolarge)
-	    if (((double)rnd69069()/ULONG_MAX) <= fraction) {
-	      if (!stdo)
-		fprintf(fout,"%ld %ld\n",n+1,element+1);
-	      else
-		fprintf(stdout,"%ld %ld\n",n+1,element+1);
-	    }
-	  element=list[element];
-	}
-      }
-    }
-  }
-  if (!stdo)
-    fclose(fout);
-}
-
 int main(int argc,char **argv)
 {
-  long i;
+  unsigned long i;
   char stdi=0;
-  double min,max,maxmax;
+  double bad_value;
+  RecurrResult *result;
+  FILE *fout=NULL;
 
   if (scan_help(argc,argv))
     show_options(argv[0]);
@@ -203,23 +144,34 @@ int main(int argc,char **argv)
     series=(double**)get_multi_series(infile,&length,exclude,&dim,columns,
                                       dimset,verbosity);
 
-  maxmax=0.0;
-  for (i=0;i<dim;i++) {
-    rescale_data(series[i],length,&min,&max);
-    if (max > maxmax)
-      maxmax=max;
+  result=recurr_find((double *const *)series,length,dim,embed,delay,eps,
+		      epsset,fraction,&bad_value);
+  if (result == NULL) {
+    fprintf(stderr,"rescale_data: data ranges from %e to %e. It makes\n"
+	    "\t\tno sense to continue. Exiting!\n\n",bad_value,bad_value);
+    exit(RESCALE_DATA_ZERO_INTERVAL);
   }
 
-  if (epsset)
-    eps /= maxmax;
+  if (!stdo) {
+    fout=fopen(outfile,"w");
+    if (verbosity&VER_INPUT)
+      fprintf(stderr,"Opened %s for writing\n",outfile);
+  }
+  else {
+    if (verbosity&VER_INPUT)
+      fprintf(stderr,"Writing to stdout\n");
+  }
 
-  check_alloc(list=(long*)malloc(sizeof(long)*length));
-  check_alloc(box=(long**)malloc(sizeof(long*)*BOX));
-  for (i=0;i<BOX;i++)
-    check_alloc(box[i]=(long*)malloc(sizeof(long)*BOX));
+  for (i=0;i<result->count;i++) {
+    if (!stdo)
+      fprintf(fout,"%ld %ld\n",result->point[i],result->neighbor[i]);
+    else
+      fprintf(stdout,"%ld %ld\n",result->point[i],result->neighbor[i]);
+  }
+  if (!stdo)
+    fclose(fout);
 
-  make_multi_box(series,box,list,length,BOX,dim,embed,delay,eps);
-  lfind_neighbors();
+  recurr_free(result);
 
   return 0;
 }

--- a/tests/test_recurr_bindings.py
+++ b/tests/test_recurr_bindings.py
@@ -1,0 +1,227 @@
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+tisean = pytest.importorskip("tisean")
+
+# The CLI prints with "%e" (6 digits after the point, ~7 significant
+# digits), so comparisons against numbers parsed from its stdout can't be
+# tighter than that text roundtrip allows. recurr's own pair output is all
+# integers (no rounding involved there), but the constant-data error
+# message it reproduces is still "%e"-formatted.
+CLI_TEXT_TOL = dict(rtol=1e-6, atol=1e-6)
+
+RESCALE_DATA_ZERO_INTERVAL = 11
+
+AR_RUN = "tests/refs/ar-run_l1000.txt"
+HENON = "tests/refs/henon_l1000.txt"
+LORENZ = "tests/refs/lorenz_l1000.txt"
+RECURR_BIN = os.path.abspath("./bin/recurr")
+
+
+def run_cli(args, **kwargs):
+    result = subprocess.run(
+        [RECURR_BIN] + args,
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+    return result.stdout
+
+
+def parse_output(text):
+    """recurr prints one '<point> <neighbor>' pair per line, 1-based
+    indices, no header/comment lines at all."""
+    rows = [
+        [int(x) for x in line.split()]
+        for line in text.splitlines()
+        if line.strip()
+    ]
+    return np.array(rows, dtype=np.int64).reshape(-1, 2)
+
+
+def load_multi_series(path, columns, length=None, exclude=0):
+    """Replicates get_multi_series()'s -x/-l/-c handling: skip `exclude`
+    lines, keep up to `length` of the rest, then pick `columns` (1-indexed,
+    in the given order). Returns a (dim, length) array - recurr_find()
+    does its own rescaling internally, so unlike ar-model's loader this
+    does no centering."""
+    raw = np.loadtxt(path)
+    if raw.ndim == 1:
+        raw = raw.reshape(-1, 1)
+    if exclude:
+        raw = raw[exclude:]
+    if length is not None:
+        raw = raw[:length]
+    raw = raw[:, [c - 1 for c in columns]]
+    return raw.T.copy()
+
+
+CASES = [
+    # label, args, datafile, columns, length, exclude, embed, delay, eps, eps_is_raw
+    ("defaults", [], AR_RUN, [1], None, 0, 2, 1, 1.e-3, False),
+    ("explicit_default_m", ["-m1,2"], AR_RUN, [1], None, 0, 2, 1, 1.e-3, False),
+    ("embed_3", ["-m1,3"], AR_RUN, [1], None, 0, 3, 1, 1.e-3, False),
+    ("delay_2", ["-r0.1", "-d2"], AR_RUN, [1], None, 0, 2, 2, 0.1, True),
+    ("raw_eps", ["-r0.1"], AR_RUN, [1], None, 0, 2, 1, 0.1, True),
+    ("length_100", ["-r0.1", "-l100"], AR_RUN, [1], 100, 0, 2, 1, 0.1, True),
+    ("exclude_50", ["-r0.1", "-x50", "-l100"], AR_RUN, [1], 100, 50, 2, 1, 0.1, True),
+    ("column_2", ["-c2", "-r0.1"], HENON, [2], None, 0, 2, 1, 0.1, True),
+    (
+        "dim2_henon",
+        ["-m2,2", "-r0.1", "-l200"],
+        HENON,
+        [1, 2],
+        200,
+        0,
+        2,
+        1,
+        0.1,
+        True,
+    ),
+    (
+        "dim2_henon_reordered_columns",
+        ["-m2,2", "-c2,1", "-r0.1", "-l200"],
+        HENON,
+        [2, 1],
+        200,
+        0,
+        2,
+        1,
+        0.1,
+        True,
+    ),
+    (
+        "dim3_lorenz",
+        ["-m3,2", "-r0.1", "-l200"],
+        LORENZ,
+        [1, 2, 3],
+        200,
+        0,
+        2,
+        1,
+        0.1,
+        True,
+    ),
+    ("verbosity_0", ["-V0", "-r0.1", "-l100"], AR_RUN, [1], 100, 0, 2, 1, 0.1, True),
+]
+
+
+@pytest.mark.parametrize(
+    "label,args,datafile,columns,length,exclude,embed,delay,eps,eps_is_raw",
+    CASES,
+    ids=[c[0] for c in CASES],
+)
+def test_find_matches_cli(
+    label, args, datafile, columns, length, exclude, embed, delay, eps, eps_is_raw
+):
+    out = run_cli(args + [datafile])
+    cli_pairs = parse_output(out)
+
+    series = load_multi_series(datafile, columns, length=length, exclude=exclude)
+    result = tisean.recurr.find(
+        series, embed=embed, delay=delay, eps=eps, eps_is_raw=eps_is_raw
+    )
+
+    assert result.count == len(cli_pairs)
+    py_pairs = np.stack([result.point, result.neighbor], axis=1)
+    np.testing.assert_array_equal(py_pairs, cli_pairs)
+
+
+def test_find_matches_cli_dash_o_output_file(tmp_path):
+    outfile = tmp_path / "out.rec"
+    run_cli(["-m1,2", "-d1", "-r0.1", "-l200", "-o" + str(outfile), AR_RUN])
+
+    cli_pairs = parse_output(outfile.read_text())
+
+    series = load_multi_series(AR_RUN, [1], length=200)
+    result = tisean.recurr.find(series, embed=2, delay=1, eps=0.1, eps_is_raw=True)
+
+    py_pairs = np.stack([result.point, result.neighbor], axis=1)
+    np.testing.assert_array_equal(py_pairs, cli_pairs)
+
+
+def test_find_default_kwargs_match_cli_documented_defaults():
+    # show_options(): -m default "1,2" (dim,embed), -d default 1, -r
+    # default "(data interval)/1000" i.e. eps=1.e-3 used directly in the
+    # already-rescaled [0,1) space (epsset stays unset), -% default 100.0
+    # i.e. fraction=1.0.
+    series = load_multi_series(AR_RUN, [1])
+
+    default = tisean.recurr.find(series)
+    explicit = tisean.recurr.find(
+        series, embed=2, delay=1, eps=1.e-3, eps_is_raw=False, fraction=1.0
+    )
+
+    assert default.count == explicit.count
+    np.testing.assert_array_equal(default.point, explicit.point)
+    np.testing.assert_array_equal(default.neighbor, explicit.neighbor)
+
+
+def test_find_rejects_constant_dimension_like_cli(tmp_path):
+    datafile = tmp_path / "constant.txt"
+    datafile.write_text("\n".join(["1.5"] * 20) + "\n")
+
+    result = subprocess.run(
+        [RECURR_BIN, str(datafile)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == RESCALE_DATA_ZERO_INTERVAL
+    assert "data ranges from 1.500000e+00 to 1.500000e+00" in result.stderr
+
+    series = np.full((1, 20), 1.5)
+    with pytest.raises(ValueError, match=r"1\.500000"):
+        tisean.recurr.find(series)
+
+
+def test_find_matches_cli_with_fraction_below_one_in_fresh_process():
+    # rand.c's rnd_init() only actually (re)seeds once per process (see
+    # source_c/routines/rand.c's static rnd_init_was_set guard), and
+    # recurr_find() always seeds with the CLI's own fixed value
+    # (0x9834725L). Any other test in this same pytest process that has
+    # already exercised the RNG (directly, or indirectly through another
+    # tisean binding) would leave stale state behind, so a fraction < 1.0
+    # comparison against a fresh CLI subprocess must run the Python side in
+    # its own fresh subprocess too.
+    args = ["-m1,2", "-d1", "-r0.1", "-%50", "-l200"]
+    cli_pairs = parse_output(run_cli(args + [AR_RUN]))
+
+    script = (
+        "import numpy as np, tisean\n"
+        f"raw = np.loadtxt({AR_RUN!r})[:200]\n"
+        "series = raw.reshape(1, -1)\n"
+        "result = tisean.recurr.find(series, embed=2, delay=1, eps=0.1,\n"
+        "                             eps_is_raw=True, fraction=0.5)\n"
+        "for p, n in zip(result.point, result.neighbor):\n"
+        "    print(p, n)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    py_pairs = parse_output(result.stdout)
+
+    np.testing.assert_array_equal(py_pairs, cli_pairs)
+
+
+def test_find_fraction_one_is_deterministic_regardless_of_prior_rng_use():
+    # Unlike the fraction < 1.0 case above, fraction=1.0 always keeps every
+    # candidate found (rnd69069()/ULONG_MAX <= 1.0 is always true), so the
+    # result must be identical no matter what RNG state earlier calls left
+    # behind.
+    series = load_multi_series(AR_RUN, [1], length=200)
+
+    tisean.recurr.find(series, embed=2, delay=1, eps=0.1, eps_is_raw=True, fraction=0.3)
+    result = tisean.recurr.find(
+        series, embed=2, delay=1, eps=0.1, eps_is_raw=True, fraction=1.0
+    )
+
+    cli_pairs = parse_output(
+        run_cli(["-m1,2", "-d1", "-r0.1", "-l200", AR_RUN])
+    )
+    py_pairs = np.stack([result.point, result.neighbor], axis=1)
+    np.testing.assert_array_equal(py_pairs, cli_pairs)


### PR DESCRIPTION
Generated by the TAEP Engineer worker.