### PR TITLE
Fix #50: Wrap `mem_spec` as a Python binding

### DIFF
--- a/include/mem_spec.h
+++ b/include/mem_spec.h
@@ -1,0 +1,67 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant API for the mem_spec routine: fits an AR power-spectrum model
+   via Burg's method and evaluates the implied power spectrum. Extracted
+   out of source_c/mem_spec.c (getcoefs()/powcoef()) so it can be called
+   both from the mem_spec CLI and from other bindings (e.g. Python)
+   without going through global state, argv parsing, or the
+   process-exiting error path in variance(). */
+
+#ifndef _MEM_SPEC_H
+#define _MEM_SPEC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  unsigned long poles;  /* number of AR poles fitted */
+  double sigma2;         /* residual variance of the Burg fit ("pm") */
+  double *coef;          /* [poles] AR coefficients */
+} MemSpecModel;
+
+/* Fits an AR model to series[0..length-1] via Burg's method, the same way
+   the mem_spec CLI does it (mean-center the raw series, then run the
+   Burg recursion for `poles` reflection coefficients). series is not
+   modified. Returns NULL if poles >= length (too many poles for the
+   data) or if series is constant (zero variance, mirroring variance()'s
+   hard-exit case but without exiting the process). */
+MemSpecModel *mem_spec_fit(const double *series, unsigned long length,
+			    unsigned long poles);
+void mem_spec_free(MemSpecModel *model);
+
+/* Evaluates the power spectrum implied by `model` at `count` frequencies
+   fdt = i/(2*count) for i in 0..count-1 (i.e. covering [0,0.5) in units
+   of the sampling rate), matching powcoef()'s transfer-function
+   evaluation in mem_spec.c. freq and spec must each hold `count` doubles
+   allocated by the caller; freq[i] is fdt*samplingrate and spec[i] is
+   model->sigma2 divided by the squared transfer function magnitude
+   (unscaled - the mem_spec CLI additionally divides by sqrt(length)
+   when writing to a file but not when writing to stdout; callers that
+   need that scaling must apply it themselves). */
+void mem_spec_spectrum(const MemSpecModel *model, unsigned long count,
+			double samplingrate, double *freq, double *spec);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(pybind11 CONFIG REQUIRED)
 set(TISEAN_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 # Only the sources ar-model/low121/histogram/polypar/corr/xcor/av-d2/mutual/
-# extrema/recurr/xzero need. Other routines get added here as they get their own
-# reentrant API extracted.
+# extrema/recurr/xzero/mem_spec need. Other routines get added here as they
+# get their own reentrant API extracted.
 pybind11_add_module(_tisean
   src/bindings.cpp
   ${TISEAN_ROOT}/source_c/api/ar_model_api.c
@@ -26,6 +26,7 @@ pybind11_add_module(_tisean
   ${TISEAN_ROOT}/source_c/api/extrema_api.c
   ${TISEAN_ROOT}/source_c/api/xzero_api.c
   ${TISEAN_ROOT}/source_c/api/recurr_api.c
+  ${TISEAN_ROOT}/source_c/api/mem_spec_api.c
   ${TISEAN_ROOT}/source_c/routines/check_alloc.c
   ${TISEAN_ROOT}/source_c/routines/variance.c
   ${TISEAN_ROOT}/source_c/routines/invert_matrix.c

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -20,6 +20,7 @@
 #include "extrema.h"
 #include "xzero.h"
 #include "recurr.h"
+#include "mem_spec.h"
 
 namespace py = pybind11;
 
@@ -544,6 +545,55 @@ recurr_find_binding(py::array_t<double, py::array::c_style | py::array::forcecas
   return std::make_unique<RecurrResultWrapper>(result);
 }
 
+// Owns a MemSpecModel* and exposes its fields as numpy arrays. Not
+// copyable since MemSpecModel doesn't support that; pybind11 holds it by
+// unique_ptr.
+class MemSpecModelWrapper {
+public:
+  explicit MemSpecModelWrapper(MemSpecModel *model) : model_(model) {}
+  MemSpecModelWrapper(const MemSpecModelWrapper &) = delete;
+  MemSpecModelWrapper &operator=(const MemSpecModelWrapper &) = delete;
+  ~MemSpecModelWrapper() { mem_spec_free(model_); }
+
+  unsigned long poles() const { return model_->poles; }
+  double sigma2() const { return model_->sigma2; }
+
+  py::array_t<double> coef() const {
+    py::array_t<double> out((py::ssize_t)model_->poles);
+    auto buf = out.mutable_unchecked<1>();
+    for (unsigned long i = 0; i < model_->poles; i++)
+      buf(i) = model_->coef[i];
+    return out;
+  }
+
+  std::pair<py::array_t<double>, py::array_t<double>>
+  spectrum(unsigned long out, double samplingrate) const {
+    py::array_t<double> freq((py::ssize_t)out), spec((py::ssize_t)out);
+    mem_spec_spectrum(model_, out, samplingrate, freq.mutable_data(), spec.mutable_data());
+    return {freq, spec};
+  }
+
+private:
+  MemSpecModel *model_;
+};
+
+std::unique_ptr<MemSpecModelWrapper>
+mem_spec_fit_binding(py::array_t<double, py::array::c_style | py::array::forcecast> series,
+		      unsigned long poles)
+{
+  if (series.ndim() != 1)
+    throw std::invalid_argument("series must be a 1D array");
+
+  auto length = (unsigned long)series.shape(0);
+  MemSpecModel *model = mem_spec_fit(series.data(), length, poles);
+  if (model == nullptr)
+    throw std::invalid_argument(
+	"poles must be < len(series), and series must not be constant "
+	"(zero variance)");
+
+  return std::make_unique<MemSpecModelWrapper>(model);
+}
+
 } // namespace
 
 PYBIND11_MODULE(_tisean, m)
@@ -786,4 +836,29 @@ PYBIND11_MODULE(_tisean, m)
       "and `delay` match the CLI's -m (embedding dimension part) and -d; "
       "`fraction` matches the CLI's -% (as a 0..1 fraction rather than a "
       "percentage).");
+
+  auto mem_spec = m.def_submodule(
+      "mem_spec", "AR power spectrum estimation via Burg's method (source_c/mem_spec.c)");
+
+  py::class_<MemSpecModelWrapper>(mem_spec, "MemSpecModel")
+      .def_property_readonly("poles", &MemSpecModelWrapper::poles)
+      .def_property_readonly("sigma2", &MemSpecModelWrapper::sigma2,
+			      "Residual variance of the Burg fit")
+      .def_property_readonly("coef", &MemSpecModelWrapper::coef,
+			      "AR (reflection) coefficients, shape (poles,)")
+      .def("spectrum", &MemSpecModelWrapper::spectrum, py::arg("out") = 2000,
+	   py::arg("samplingrate") = 1.0,
+	   "Evaluate the power spectrum implied by this model at `out`\n"
+	   "frequencies spaced over [0, samplingrate/2), matching the "
+	   "mem_spec CLI's -P/-f options. Returns a (freq, spec) tuple of "
+	   "1D arrays, each of length `out`. spec is unscaled, matching "
+	   "what the CLI prints to stdout; the CLI additionally divides by "
+	   "sqrt(len(series)) only when writing to a file with -o.");
+
+  mem_spec.def(
+      "fit", &mem_spec_fit_binding, py::arg("series"), py::arg("poles") = 128,
+      "Fit an AR power-spectrum model to `series` via Burg's method, "
+      "matching the mem_spec CLI's -p option (default 128). series is "
+      "mean-centered internally the same way the CLI does it before "
+      "fitting; the input array itself is not modified.");
 }

--- a/python/tisean/__init__.py
+++ b/python/tisean/__init__.py
@@ -1,4 +1,4 @@
 from . import _tisean
-from ._tisean import ar_model, low121, histogram, polypar, corr, xcor, av_d2, mutual, extrema, recurr, xzero
+from ._tisean import ar_model, low121, histogram, polypar, corr, xcor, av_d2, mutual, extrema, recurr, xzero, mem_spec
 
-__all__ = ["ar_model", "low121", "histogram", "polypar", "corr", "xcor", "av_d2", "mutual", "extrema", "recurr", "xzero"]
+__all__ = ["ar_model", "low121", "histogram", "polypar", "corr", "xcor", "av_d2", "mutual", "extrema", "recurr", "xzero", "mem_spec"]

--- a/source_c/CMakeLists.txt
+++ b/source_c/CMakeLists.txt
@@ -4,7 +4,7 @@ set(TISEAN_C_PROGRAMS
   poincare rescale false_nearest
   lyap_r lyap_k lyap_spec d2 makenoise nrlazy
   lzo-test lfo-run lfo-test rbf polynom polyback polynomp
-  mem_spec pca ghkss lfo-ar boxcount fsle
+  pca ghkss lfo-ar boxcount fsle
   resample nstat_z sav_gol delay lzo-gm arima-model
   lzo-run ar-run
 )
@@ -15,9 +15,9 @@ foreach(prog ${TISEAN_C_PROGRAMS})
   install(TARGETS ${prog} RUNTIME DESTINATION bin)
 endforeach()
 
-# ar-model, low121, histogram, polypar, corr, xcor, av-d2, mutual, extrema
-# recurr, and xzero use the reentrant APIs in api/ (also used by the Python
-# bindings under python/) instead of duplicating the math inline.
+# ar-model, low121, histogram, polypar, corr, xcor, av-d2, mutual, extrema,
+# recurr, xzero, and mem_spec use the reentrant APIs in api/ (also used by
+# the Python bindings under python/) instead of duplicating the math inline.
 add_executable(ar-model ar-model.c api/ar_model_api.c)
 target_link_libraries(ar-model PRIVATE ddtsa)
 install(TARGETS ar-model RUNTIME DESTINATION bin)
@@ -60,3 +60,7 @@ install(TARGETS xzero RUNTIME DESTINATION bin)
 add_executable(recurr recurr.c api/recurr_api.c)
 target_link_libraries(recurr PRIVATE ddtsa)
 install(TARGETS recurr RUNTIME DESTINATION bin)
+
+add_executable(mem_spec mem_spec.c api/mem_spec_api.c)
+target_link_libraries(mem_spec PRIVATE ddtsa)
+install(TARGETS mem_spec RUNTIME DESTINATION bin)

--- a/source_c/api/mem_spec_api.c
+++ b/source_c/api/mem_spec_api.c
@@ -1,0 +1,163 @@
+/*
+ *   This file is part of TISEAN
+ *
+ *   Copyright (c) 1998-2007 Rainer Hegger, Holger Kantz, Thomas Schreiber
+ *
+ *   TISEAN is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   TISEAN is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with TISEAN; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* Reentrant core of mem_spec, factored out of source_c/mem_spec.c so it
+   has no dependency on argv parsing, file-scope globals, or the
+   process-exiting error path in the generic variance() library routine
+   it used to call. The math here (mean/std via a plain sequential sum,
+   Burg's recursion for the AR reflection coefficients in getcoefs(), and
+   the transfer-function evaluation in powcoef()) is unchanged from
+   main(). */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../routines/tsa.h"
+#include "../../include/mem_spec.h"
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932385E0
+#endif
+
+/* series is a caller-owned scratch buffer of `length` doubles (already
+   mean-centered); it is mutated in place, mirroring the original
+   getcoefs()'s in-place updates through its (self-advancing) global
+   `series` pointer, but the pointer value handed to us is left
+   untouched so the caller can still free() it afterwards. */
+static double burg_coefs(double *series, unsigned long length,
+			  unsigned long poles, double *coef)
+{
+  long i, j, hp = (long)poles - 1;
+  double ret = 0.0, *cov, *help, *wseries, h1, h2;
+
+  check_alloc(cov = (double *)malloc(sizeof(double) * length));
+  check_alloc(help = (double *)malloc(sizeof(double) * poles));
+
+  for (i = 0; i < (long)length; i++)
+    ret += series[i] * series[i];
+  ret /= (double)length;
+
+  for (i = 0; i < (long)length; i++)
+    cov[i] = series[i];
+  wseries = series + 1;
+
+  for (i = 0; i < (long)poles; i++) {
+    h1 = h2 = 0.0;
+    for (j = 0; j < (long)length - i - 1; j++) {
+      h1 += cov[j] * wseries[j];
+      h2 += cov[j] * cov[j] + wseries[j] * wseries[j];
+    }
+    coef[i] = 2.0 * h1 / h2;
+    ret *= (1.0 - coef[i] * coef[i]);
+    for (j = 0; j < i; j++)
+      coef[j] = help[j] - coef[i] * help[i - 1 - j];
+    if (i == hp)
+      break;
+    for (j = 0; j <= i; j++)
+      help[j] = coef[j];
+    for (j = 0; j < (long)length - i - 1; j++) {
+      cov[j] -= help[i] * wseries[j];
+      wseries[j] = wseries[j + 1] - help[i] * cov[j + 1];
+    }
+  }
+
+  free(cov);
+  free(help);
+
+  return ret;
+}
+
+MemSpecModel *mem_spec_fit(const double *series, unsigned long length,
+			    unsigned long poles)
+{
+  unsigned long i;
+  double h, av, var, *centered, *coef;
+  MemSpecModel *model;
+
+  if (poles >= length)
+    return NULL;
+
+  av = var = 0.0;
+  for (i = 0; i < length; i++) {
+    h = series[i];
+    av += h;
+    var += h * h;
+  }
+  av /= (double)length;
+  var = sqrt(fabs(var / (double)length - av * av));
+  if (var == 0.0)
+    return NULL;
+
+  check_alloc(centered = (double *)malloc(sizeof(double) * length));
+  for (i = 0; i < length; i++)
+    centered[i] = series[i] - av;
+
+  check_alloc(coef = (double *)malloc(sizeof(double) * poles));
+
+  check_alloc(model = (MemSpecModel *)malloc(sizeof(MemSpecModel)));
+  model->poles = poles;
+  model->coef = coef;
+  model->sigma2 = burg_coefs(centered, length, poles, coef);
+
+  free(centered);
+
+  return model;
+}
+
+void mem_spec_free(MemSpecModel *model)
+{
+  if (model == NULL)
+    return;
+  free(model->coef);
+  free(model);
+}
+
+static double transfer_pow(double dt, const double *coef, unsigned long poles)
+{
+  unsigned long i;
+  double si = 0.0, sr = 1.0, zr = 1.0, zi = 0.0, h, omdt, hr, hi;
+
+  omdt = 2.0 * M_PI * dt;
+  hr = cos(omdt);
+  hi = sin(omdt);
+
+  for (i = 0; i < poles; i++) {
+    h = zr;
+    zr = zr * hr - zi * hi;
+    zi = h * hi + zi * hr;
+    sr -= coef[i] * zr;
+    si -= coef[i] * zi;
+  }
+  return (sr * sr + si * si);
+}
+
+void mem_spec_spectrum(const MemSpecModel *model, unsigned long count,
+			double samplingrate, double *freq, double *spec)
+{
+  unsigned long i;
+  double fdt, pow_spec;
+
+  for (i = 0; i < count; i++) {
+    fdt = i / (2.0 * (double)count);
+    pow_spec = transfer_pow(fdt, model->coef, model->poles);
+    freq[i] = fdt * samplingrate;
+    spec[i] = model->sigma2 / pow_spec;
+  }
+}

--- a/source_c/mem_spec.c
+++ b/source_c/mem_spec.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include "routines/tsa.h"
+#include "../include/mem_spec.h"
 #include <math.h>
 
 #define WID_STR "Estimates the power spectrum of the data"
@@ -94,71 +95,13 @@ void scan_options(int argc,char **argv)
   }
 }
 
-double getcoefs(double *coef)
-{
-  long i,j,hp=(long)poles-1;
-  double ret=0.0,*cov,*help,h1,h2;
-  
-  check_alloc(cov=(double*)malloc(sizeof(double)*length));
-  check_alloc(help=(double*)malloc(sizeof(double)*poles));
-
-  for (i=0;i<length;i++) 
-    ret += series[i]*series[i];
-  ret /= length;
-  
-  for (i=0;i<length;i++)
-    cov[i]=series[i];
-  series++;
-
-  for (i=0;i<poles;i++) {
-    h1=h2=0.0;
-    for (j=0;j<length-i-1;j++) {
-      h1 += cov[j]*series[j];
-      h2 += cov[j]*cov[j]+series[j]*series[j];
-    }
-    coef[i]=2.0*h1/h2;
-    ret *= (1.0-coef[i]*coef[i]);
-    for (j=0;j<i;j++)
-      coef[j]=help[j]-coef[i]*help[i-1-j];
-    if (i == hp)
-      break;
-    for (j=0;j<=i;j++)
-      help[j]=coef[j];
-    for (j=0;j<length-i-1;j++) {
-      cov[j] -= help[i]*series[j];
-      series[j]=series[j+1]-help[i]*cov[j+1];
-    }
-  }
-  free(cov);
-  free(help);
-
-  return ret;
-}
-double powcoef(double dt,double *coef)
-{
-  int i;
-  double si=0.0,sr=1.0,zr=1.0,zi=0.0,h,omdt,hr,hi;
-  
-  omdt=2.0*M_PI*dt;
-  hr=cos(omdt);
-  hi=sin(omdt);
-  
-  for (i=0;i<poles;i++) {
-    h=zr;
-    zr=zr*hr-zi*hi;
-    zi=h*hi+zi*hr;
-    sr -= coef[i]*zr;
-    si -= coef[i]*zi;
-  }
-  return (sr*sr+si*si);
-}
-
 int main(int argc,char **argv)
 {
   char stdi=0;
-  double fdt,pm,pow_spec,*cof,av,var;
+  double pm,*cof,*freq,*spec;
   long i;
   FILE *fout;
+  MemSpecModel *model;
 
   if (scan_help(argc,argv))
     show_options(argv[0]);
@@ -195,13 +138,17 @@ int main(int argc,char **argv)
     exit(MEM_SPEC_TOO_MANY_POLES);
   }
 
-  variance(series,length,&av,&var);
-  for (i=0;i<length;i++)
-    series[i] -= av;
+  model=mem_spec_fit(series,length,poles);
+  if (model == NULL) {
+    fprintf(stderr,"Variance of the data is zero. Exiting!\n\n");
+    exit(VARIANCE_VAR_EQ_ZERO);
+  }
+  pm=model->sigma2;
+  cof=model->coef;
 
-  check_alloc(cof=(double*)malloc(sizeof(double)*poles));
-
-  pm=getcoefs(cof);
+  check_alloc(freq=(double*)malloc(sizeof(double)*out));
+  check_alloc(spec=(double*)malloc(sizeof(double)*out));
+  mem_spec_spectrum(model,out,samplingrate,freq,spec);
 
   if (!stdo) {
     fout=fopen(outfile,"w");
@@ -213,10 +160,8 @@ int main(int argc,char **argv)
 	fprintf(fout,"#%ld %e\n",i+1,cof[i]);
     }
     for(i=0;i<out;i++) {
-      fdt=i/(2.0*out);
-      pow_spec=powcoef(fdt,cof);
-      fprintf(fout,"%e %e\n",fdt*samplingrate,
-	      pm/pow_spec/sqrt((double)length));
+      fprintf(fout,"%e %e\n",freq[i],
+	      spec[i]/sqrt((double)length));
       fflush(fout);
     }
     fclose(fout);
@@ -230,13 +175,15 @@ int main(int argc,char **argv)
 	fprintf(stdout,"#%ld %e\n",i+1,cof[i]);
     }
     for(i=0;i<out;i++) {
-      fdt=i/(2.0*out);
-      pow_spec=powcoef(fdt,cof);
-      fprintf(stdout,"%e %e\n",fdt*samplingrate,
-	      pm/pow_spec/*/sqrt((double)length)*/);
+      fprintf(stdout,"%e %e\n",freq[i],
+	      spec[i]/*/sqrt((double)length)*/);
     }
   }
-  
+
+  mem_spec_free(model);
+  free(freq);
+  free(spec);
+
   return 0;
 }
 

--- a/tests/test_mem_spec_bindings.py
+++ b/tests/test_mem_spec_bindings.py
@@ -1,0 +1,214 @@
+import os
+import subprocess
+
+import numpy as np
+import pytest
+
+tisean = pytest.importorskip("tisean")
+
+# The CLI prints with "%e" (6 digits after the point, ~7 significant
+# digits), so comparisons against numbers parsed from its stdout can't be
+# tighter than that text roundtrip allows.
+CLI_TEXT_TOL = dict(rtol=1e-6, atol=1e-6)
+
+MEM_SPEC_TOO_MANY_POLES = 82
+VARIANCE_VAR_EQ_ZERO = 23
+
+AR_RUN = "tests/refs/ar-run_l1000.txt"
+HENON = "tests/refs/henon_l1000.txt"
+MEM_SPEC_BIN = os.path.abspath("./bin/mem_spec")
+
+
+def run_cli(args, **kwargs):
+    result = subprocess.run(
+        [MEM_SPEC_BIN] + args,
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+    return result.stdout
+
+
+def parse_output(text):
+    """Returns (freq, spec) arrays parsed from the plain (non-comment)
+    "%e %e" data rows; "#..." header/coefficient rows (only present with
+    -V2/-V3) are skipped."""
+    rows = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        rows.append([float(x) for x in line.split()])
+    data = np.array(rows)
+    return data[:, 0], data[:, 1]
+
+
+def load_series(path, column=1, length=None, exclude=0):
+    """Replicates get_series()'s -x/-l/-c handling: skip `exclude` lines,
+    keep up to `length` of the rest, then pick `column` (1-indexed)."""
+    raw = np.loadtxt(path)
+    if raw.ndim == 1:
+        raw = raw.reshape(-1, 1)
+    if exclude:
+        raw = raw[exclude:]
+    if length is not None:
+        raw = raw[:length]
+    return raw[:, column - 1].copy()
+
+
+CASES = [
+    # label, args, datafile, column, poles, out, samplingrate, length, exclude
+    ("defaults", [], AR_RUN, 1, 128, 2000, 1.0, None, 0),
+    ("poles_1", ["-p1", "-P200"], AR_RUN, 1, 1, 200, 1.0, None, 0),
+    ("poles_5", ["-p5", "-P200"], AR_RUN, 1, 5, 200, 1.0, None, 0),
+    ("poles_20", ["-p20", "-P200"], AR_RUN, 1, 20, 200, 1.0, None, 0),
+    ("out_1", ["-p5", "-P1"], AR_RUN, 1, 5, 1, 1.0, None, 0),
+    ("out_100", ["-p5", "-P100"], AR_RUN, 1, 5, 100, 1.0, None, 0),
+    ("samplingrate", ["-p5", "-P100", "-f2.5"], AR_RUN, 1, 5, 100, 2.5, None, 0),
+    ("column_2", ["-p5", "-P100", "-c2"], HENON, 2, 5, 100, 1.0, None, 0),
+    ("length", ["-p5", "-P100", "-l300"], AR_RUN, 1, 5, 100, 1.0, 300, 0),
+    ("exclude", ["-p5", "-P100", "-x50"], AR_RUN, 1, 5, 100, 1.0, None, 50),
+    (
+        "length_and_exclude",
+        ["-p5", "-P100", "-l300", "-x50"],
+        AR_RUN,
+        1,
+        5,
+        100,
+        1.0,
+        300,
+        50,
+    ),
+    ("verbosity_0", ["-p5", "-P100", "-V0"], AR_RUN, 1, 5, 100, 1.0, None, 0),
+    ("verbosity_3_prints_coeffs", ["-p5", "-P100", "-V3"], AR_RUN, 1, 5, 100, 1.0, None, 0),
+]
+
+
+@pytest.mark.parametrize(
+    "label,args,datafile,column,poles,out,samplingrate,length,exclude",
+    CASES,
+    ids=[c[0] for c in CASES],
+)
+def test_spectrum_matches_cli(
+    label, args, datafile, column, poles, out, samplingrate, length, exclude
+):
+    cli_out = run_cli(args + [datafile])
+    cli_freq, cli_spec = parse_output(cli_out)
+
+    series = load_series(datafile, column=column, length=length, exclude=exclude)
+    model = tisean.mem_spec.fit(series, poles=poles)
+    freq, spec = model.spectrum(out=out, samplingrate=samplingrate)
+
+    assert model.poles == poles
+    np.testing.assert_allclose(freq, cli_freq, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(spec, cli_spec, **CLI_TEXT_TOL)
+
+
+def test_spectrum_matches_cli_dash_o_output_file_scaling(tmp_path):
+    # Writing to a file (-o) divides the printed spectrum by sqrt(length)
+    # on top of the stdout value - mem_spec.c's main() does this only in
+    # its file-output branch (a longstanding quirk of the CLI, preserved
+    # verbatim by the refactor). The Python binding always returns the
+    # stdout-style (unscaled) values, so callers who want the -o scaling
+    # have to apply it themselves.
+    outfile = tmp_path / "out.spec"
+    poles, out = 5, 100
+    run_cli(["-p" + str(poles), "-P" + str(out), "-o" + str(outfile), AR_RUN])
+
+    cli_freq, cli_spec = parse_output(outfile.read_text())
+
+    series = load_series(AR_RUN)
+    model = tisean.mem_spec.fit(series, poles=poles)
+    freq, spec = model.spectrum(out=out)
+
+    np.testing.assert_allclose(freq, cli_freq, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(
+        spec / np.sqrt(len(series)), cli_spec, **CLI_TEXT_TOL
+    )
+
+
+def test_fit_exposes_sigma2_and_coef():
+    series = load_series(AR_RUN)
+    model = tisean.mem_spec.fit(series, poles=10)
+
+    assert model.poles == 10
+    assert model.coef.shape == (10,)
+    assert isinstance(model.sigma2, float)
+    assert model.sigma2 > 0
+
+
+def test_fit_default_poles_matches_cli_default():
+    # No -p at all: the CLI's documented default is 128.
+    out_pts = 50
+    cli_out = run_cli(["-P" + str(out_pts), AR_RUN])
+    cli_freq, cli_spec = parse_output(cli_out)
+
+    series = load_series(AR_RUN)
+    default_model = tisean.mem_spec.fit(series)
+    explicit_model = tisean.mem_spec.fit(series, poles=128)
+
+    assert default_model.poles == explicit_model.poles == 128
+    np.testing.assert_allclose(default_model.coef, explicit_model.coef)
+
+    freq, spec = default_model.spectrum(out=out_pts)
+    np.testing.assert_allclose(freq, cli_freq, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(spec, cli_spec, **CLI_TEXT_TOL)
+
+
+def test_spectrum_default_out_and_samplingrate_match_cli_defaults():
+    # No -P/-f at all: the CLI's documented defaults are out=2000, f=1.0.
+    cli_out = run_cli(["-p5", AR_RUN])
+    cli_freq, cli_spec = parse_output(cli_out)
+    assert len(cli_freq) == 2000
+
+    series = load_series(AR_RUN)
+    model = tisean.mem_spec.fit(series, poles=5)
+
+    default_freq, default_spec = model.spectrum()
+    explicit_freq, explicit_spec = model.spectrum(out=2000, samplingrate=1.0)
+
+    np.testing.assert_array_equal(default_freq, explicit_freq)
+    np.testing.assert_array_equal(default_spec, explicit_spec)
+    np.testing.assert_allclose(default_freq, cli_freq, **CLI_TEXT_TOL)
+    np.testing.assert_allclose(default_spec, cli_spec, **CLI_TEXT_TOL)
+
+
+def test_fit_rejects_too_many_poles_like_cli():
+    poles, length = 20, 15
+
+    result = subprocess.run(
+        [MEM_SPEC_BIN, f"-p{poles}", f"-l{length}", AR_RUN],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == MEM_SPEC_TOO_MANY_POLES
+
+    series = load_series(AR_RUN, length=length)
+    with pytest.raises(ValueError):
+        tisean.mem_spec.fit(series, poles=poles)
+
+
+def test_fit_rejects_constant_data_like_cli(tmp_path):
+    datafile = tmp_path / "constant.txt"
+    datafile.write_text("\n".join(["1.5"] * 200) + "\n")
+
+    result = subprocess.run(
+        [MEM_SPEC_BIN, "-p5", str(datafile)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == VARIANCE_VAR_EQ_ZERO
+
+    series = np.full(200, 1.5)
+    with pytest.raises(ValueError):
+        tisean.mem_spec.fit(series, poles=5)
+
+
+def test_fit_does_not_modify_input_series():
+    series = load_series(AR_RUN)
+    original = series.copy()
+
+    tisean.mem_spec.fit(series, poles=10)
+
+    np.testing.assert_array_equal(series, original)


### PR DESCRIPTION
Generated by the TAEP Engineer worker.